### PR TITLE
Configに関するバグ修正 & RSSIの値がおかしい問題の修正

### DIFF
--- a/src/E220.cpp
+++ b/src/E220.cpp
@@ -89,7 +89,7 @@ int E220::ReceiveDataVariebleLength(byte* _rx_payload,int _length){
         byte trash[400]={0};
         int nullcount=0;
         serial_e220.readBytesUntil(STARTLETTER,trash,400);
-        serial_e220.readBytes(_rx_payload,_length+1);
+        serial_e220.readBytes(_rx_payload,_length);
         receive_msg_length=_length;
     }else{
         receive_msg_length=0;
@@ -105,7 +105,7 @@ int E220::ReceiveDataVariebleLength(byte* _rx_payload,int _length,int* rssi){
         byte trash[400]={0};
         int nullcount=0;
         serial_e220.readBytesUntil(STARTLETTER,trash,400);
-        serial_e220.readBytes(_rx_payload,_length+1);
+        serial_e220.readBytes(_rx_payload,_length);
         delay(1);//wait for rssi culcuration at E220
         *rssi=-(256-serial_e220.read());
         // dBm=256-rssi;

--- a/src/E220.cpp
+++ b/src/E220.cpp
@@ -29,15 +29,6 @@ void E220::GenerateTestMsg_2(byte* _payload, int count,int _length) {
     }
 }
 
-void E220::TransmissionData(byte* _tx_payload) {
-    byte full_transmission_buffer[200] = {0};
-    full_transmission_buffer[0] = STARTLETTER;
-    for (int i = 0; i < 199; i++) {
-        full_transmission_buffer[i + 1] = _tx_payload[i];
-    }
-    serial_e220.write(full_transmission_buffer, 200); 
-}
-
 void E220::TransmissionDataVariebleLength(byte* _tx_payload,int _length) {
     byte full_transmission_buffer[_length+1] = {0};
     full_transmission_buffer[0] = STARTLETTER;
@@ -45,57 +36,6 @@ void E220::TransmissionDataVariebleLength(byte* _tx_payload,int _length) {
         full_transmission_buffer[i + 1] = _tx_payload[i];
     }
     serial_e220.write(full_transmission_buffer, _length+1); 
-}
-
-int E220::ReceiveData(byte* _rx_payload){
-    bool isReceived=false;
-    int receive_msg_length=0;
-    if(serial_e220.available()>0){
-        byte trash[400]={0};
-        int nullcount=0;
-        serial_e220.readBytesUntil(STARTLETTER,trash,400);
-        serial_e220.readBytes(_rx_payload,199);
-        receive_msg_length=199;
-    }else{
-        receive_msg_length=0;
-    }
-    return receive_msg_length;
-}
-
-//When rssi available
-int E220::ReceiveData(byte* _rx_payload,int* rssi){
-    bool isReceived=false;
-    int receive_msg_length=0;
-    if(serial_e220.available()>0){
-        byte trash[400]={0};
-        int nullcount=0;
-        serial_e220.readBytesUntil(STARTLETTER,trash,400);
-        serial_e220.readBytes(_rx_payload,199);
-        delay(1);//wait for rssi culcuration at E220
-        *rssi=-(256-serial_e220.read());
-        // dBm=256-rssi;
-        receive_msg_length=199;
-    }else{
-        receive_msg_length=0;
-    }
-    return receive_msg_length;
-}
-
-//When Variebale length data sended
-int E220::ReceiveDataVariebleLength(byte* _rx_payload,int _length){
-    bool isReceived=false;
-    int receive_msg_length=0;
-    if(serial_e220.available()>0){
-        byte trash[400]={0};
-        int nullcount=0;
-        serial_e220.readBytesUntil(STARTLETTER,trash,400);
-        serial_e220.readBytes(_rx_payload,_length);
-        receive_msg_length=_length;
-    }else{
-        receive_msg_length=0;
-    }
-    return receive_msg_length;
-
 }
 
 int E220::ReceiveDataVariebleLength(byte* _rx_payload,int _length,int* rssi){
@@ -106,9 +46,10 @@ int E220::ReceiveDataVariebleLength(byte* _rx_payload,int _length,int* rssi){
         int nullcount=0;
         serial_e220.readBytesUntil(STARTLETTER,trash,400);
         serial_e220.readBytes(_rx_payload,_length);
-        delay(1);//wait for rssi culcuration at E220
-        *rssi=-(256-serial_e220.read());
-        // dBm=256-rssi;
+        if(rssi){
+            delay(10);//wait for rssi culcuration at E220
+            *rssi=-(256-serial_e220.read());
+        }
         receive_msg_length=_length;
     }else{
         receive_msg_length=0;

--- a/src/E220.h
+++ b/src/E220.h
@@ -11,12 +11,12 @@ class E220{
         void ResetBuff(byte* _payload,int _length);
         void GenerateTestMsg(byte* _payload, int count);
         void GenerateTestMsg_2(byte* _payload, int count,int _length);
-        void TransmissionData(byte* _tx_payload);
+        
         void TransmissionDataVariebleLength(byte* _tx_payload,int _length);
-        int ReceiveData(byte* _rx_payload);
-        int ReceiveData(byte* _rx_payload,int* rssi);
-        int ReceiveDataVariebleLength(byte* _rx_payload,int _length);
-        int ReceiveDataVariebleLength(byte* _rx_payload,int _length,int* rssi);
+        int ReceiveDataVariebleLength(byte* _rx_payload,int _length,int* rssi = nullptr);
+
+        inline void TransmissionData(byte* _tx_payload) {TransmissionDataVariebleLength(_tx_payload,199);}
+        inline int ReceiveData(byte* _rx_payload,int* rssi = nullptr) {return ReceiveDataVariebleLength(_rx_payload,199,rssi);}
     private:
         uint8_t target_address_1;
         uint8_t target_address_2;

--- a/src/config_E220.cpp
+++ b/src/config_E220.cpp
@@ -349,10 +349,10 @@ void config_E220::SetRssiByteAvailable(bool _rssi_byte_available,byte* _set_data
 void config_E220::SetTxMethod(bool _fixed,byte* _set_data_buff){
     if(_fixed){//Transeparent mode
         _set_data_buff[5]=_set_data_buff[5]&0b10111111;
-        _set_data_buff[5]=_set_data_buff[5]|0b00000000;
+        _set_data_buff[5]=_set_data_buff[5]|0b01000000;
     }else{//fixed mode
         _set_data_buff[5]=_set_data_buff[5]&0b10111111;
-        _set_data_buff[5]=_set_data_buff[5]|0b01000000;
+        _set_data_buff[5]=_set_data_buff[5]|0b00000000;
     }
 
 }

--- a/src/config_E220.cpp
+++ b/src/config_E220.cpp
@@ -104,7 +104,6 @@ void config_E220::Show(){
     byte responcedata[11]={0};
     ReadResister(0x00,11,responcedata);
     Serial.println("------configuration------");
-    Serial.print("Address(HEX):");
     Serial.print("Address(HEX): 0x");
     if (responcedata[0] < 16) { Serial.print("0"); } Serial.print(responcedata[0], HEX);
     if (responcedata[1] < 16) { Serial.print("0"); } Serial.println(responcedata[1], HEX);

--- a/src/config_E220.cpp
+++ b/src/config_E220.cpp
@@ -281,16 +281,19 @@ void config_E220::SetSubpacketLength(int _sub_length,byte* _set_data_buff){
     case 200:
         _set_data_buff[3]=_set_data_buff[3]&0b00111111;
         _set_data_buff[3]=_set_data_buff[3]|0b00000000;
-        
+        break;
     case 128:
         _set_data_buff[3]=_set_data_buff[3]&0b00111111;
         _set_data_buff[3]=_set_data_buff[3]|0b01000000;
+        break;
     case 64:
         _set_data_buff[3]=_set_data_buff[3]&0b00111111;
         _set_data_buff[3]=_set_data_buff[3]|0b10000000;
+        break;
     case 32:
         _set_data_buff[3]=_set_data_buff[3]&0b00111111;
         _set_data_buff[3]=_set_data_buff[3]|0b11000000;
+        break;
     default:
         break;
     }
@@ -310,12 +313,15 @@ void config_E220::SetTxPower(int _power,byte* _set_data_buff){
         case 13:
             _set_data_buff[3]=_set_data_buff[3]&0b11111100;
             _set_data_buff[3]=_set_data_buff[3]|0b00000001;
+            break;
         case 7:
             _set_data_buff[3]=_set_data_buff[3]&0b11111100;
             _set_data_buff[3]=_set_data_buff[3]|0b00000010;
+            break;
         case 0:
             _set_data_buff[3]=_set_data_buff[3]&0b11111100;
             _set_data_buff[3]=_set_data_buff[3]|0b00000011;
+            break;
         default:
             break;
     }

--- a/src/config_E220.cpp
+++ b/src/config_E220.cpp
@@ -167,6 +167,7 @@ void config_E220::SetAddress(int _addr,byte* _set_data_buff){
         // Serial.print("error:address<0");
     }else if(_addr<256){
         _set_data_buff[0]=_addr;
+        _set_data_buff[1]=0;
     }else if(_addr<65536){
         _set_data_buff[0]=_addr/256;
         _set_data_buff[1]=_addr%256;

--- a/src/config_E220.cpp
+++ b/src/config_E220.cpp
@@ -105,8 +105,9 @@ void config_E220::Show(){
     ReadResister(0x00,11,responcedata);
     Serial.println("------configuration------");
     Serial.print("Address(HEX):");
-    Serial.print(responcedata[0],HEX);
-    Serial.println(responcedata[1],HEX);
+    Serial.print("Address(HEX): 0x");
+    if (responcedata[0] < 16) { Serial.print("0"); } Serial.print(responcedata[0], HEX);
+    if (responcedata[1] < 16) { Serial.print("0"); } Serial.println(responcedata[1], HEX);
 
 
     Serial.print("UARTBaudrate:");

--- a/src/config_E220.cpp
+++ b/src/config_E220.cpp
@@ -166,8 +166,8 @@ void config_E220::SetAddress(int _addr,byte* _set_data_buff){
     if(_addr<0){
         // Serial.print("error:address<0");
     }else if(_addr<256){
-        _set_data_buff[0]=_addr;
-        _set_data_buff[1]=0;
+        _set_data_buff[0]=0;
+        _set_data_buff[1]=_addr;
     }else if(_addr<65536){
         _set_data_buff[0]=_addr/256;
         _set_data_buff[1]=_addr%256;

--- a/src/config_E220.cpp
+++ b/src/config_E220.cpp
@@ -302,9 +302,10 @@ void config_E220::SetSubpacketLength(int _sub_length,byte* _set_data_buff){
 void config_E220::SetRssiNoiseAvailable(bool _rssi_available,byte* _set_data_buff){
     if(_rssi_available){
         _set_data_buff[3]=_set_data_buff[3]&0b11011111;
+        _set_data_buff[3]=_set_data_buff[3]|0b00100000;
     }else{
         _set_data_buff[3]=_set_data_buff[3]&0b11011111;
-        _set_data_buff[3]=_set_data_buff[3]|0b00100000; 
+        _set_data_buff[3]=_set_data_buff[3]|0b00000000;
     }
 }
 
@@ -336,12 +337,12 @@ void config_E220::SetChannel(int _channel,byte* _set_data_buff){
 }
 //0x05
 void config_E220::SetRssiByteAvailable(bool _rssi_byte_available,byte* _set_data_buff){
-    if(!_rssi_byte_available){
-        _set_data_buff[5]=_set_data_buff[5]&0b01111111;
-        _set_data_buff[5]=_set_data_buff[5]|0b00000000;
-    }else{
+    if(_rssi_byte_available){
         _set_data_buff[5]=_set_data_buff[5]&0b01111111;
         _set_data_buff[5]=_set_data_buff[5]|0b10000000;
+    }else{
+        _set_data_buff[5]=_set_data_buff[5]&0b01111111;
+        _set_data_buff[5]=_set_data_buff[5]|0b00000000;
     }
 }
 

--- a/src/config_E220.h
+++ b/src/config_E220.h
@@ -37,7 +37,7 @@ class config_E220{
         uint32_t sf[8]={5,6,7,8,9,10,11,12};
         uint32_t bw[3]={125,250,500};
         uint32_t subpacket_length[4]={200,128,64,32};
-        uint32_t tx_power[4]={NULL,13,7,0};
+        uint32_t tx_power[4]={0xffffffff,13,7,0};
         uint32_t wor_cycle[8]={500,1000,1500,2000,2500,3000,3500,4000};
 
         


### PR DESCRIPTION
主にConfigに関するバグ修正です。

修正内容は以下の通りです。

- SetSubPacketLengthとSetTxPowerでswitchのbreakが抜けていたので修正
- SetRssiNoiseAvailableの挙動が逆だったのを修正
- SetTxMethodの挙動が逆になっているのを修正
- アドレスが256以上の時にSetAddressで255以下のアドレスを指定するとバグる問題を修正 
- SetAddressで256以下の数値を与えるとADDHに値が格納される問題を修正
- Showでのアドレス表示について、0埋めを行うように変更
  - 0x2000, 0x200といった値が区別できない状態になっていたため

- ReceiveDataVariebleLengthで取得されるRSSIの値がおかしい問題の修正（要動作確認）
- 重複するソースコードを統合
